### PR TITLE
Updated Critically Vulnerability Jsonwebtoken to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "errorhandler": "^1.1.1",
     "express": "^4.8.5",
     "express-jwt": "^0.3.1",
-    "jsonwebtoken": "^1.1.2",
+    "jsonwebtoken": "^5.0.1",
     "lodash": "^2.4.1",
     "morgan": "^1.2.3"
   }


### PR DESCRIPTION
Up v1.1.2 to v5.0.1. As per [recommendation](https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries)
Tested and all functionality holds good.

Cheers!
