### PR TITLE
Allow for front end to send either username or email as user scheme

### DIFF
--- a/user-routes.js
+++ b/user-routes.js
@@ -17,14 +17,28 @@ function createToken(user) {
 }
 
 app.post('/users', function(req, res) {
-  if (!req.body.username || !req.body.password) {
+  var username;
+  var userScheme;
+  
+  // The POST contains a username and not an email
+  if(req.body.username) {
+    username = req.body.username;
+    userScheme = 'username';
+  }
+  // The POST contains an email and not an username
+  else if(req.body.email) {
+    username = req.body.email;
+    userScheme = 'email';
+  }
+
+  if (!req.body.username && !req.body.email || !req.body.password) {
     return res.status(400).send("You must send the username and the password");
   }
-  if (_.find(users, {username: req.body.username})) {
+  if (_.find(users, {username: username}) || _.find(users, {email: username})) {
    return res.status(400).send("A user with that username already exists");
   }
 
-  var profile = _.pick(req.body, 'username', 'password', 'extra');
+  var profile = _.pick(req.body, userScheme, 'password', 'extra');
   profile.id = _.max(users, 'id').id + 1;
 
   users.push(profile);
@@ -35,13 +49,28 @@ app.post('/users', function(req, res) {
 });
 
 app.post('/sessions/create', function(req, res) {
-  if (!req.body.username || !req.body.password) {
+
+  var username;
+  var userScheme;
+  
+  // The POST contains a username and not an email
+  if(req.body.username) {
+    username = req.body.username;
+    userScheme = 'username';
+  }
+  // The POST contains an email and not an username
+  else if(req.body.email) {
+    username = req.body.email;
+    userScheme = 'email';
+  }
+
+  if (!req.body.username && !req.body.email || !req.body.password) {
     return res.status(400).send("You must send the username and the password");
   }
 
-  var user = _.find(users, {username: req.body.username});
+  var user = _.find(users, {username: username}) || _.find(users, {email: username});
   if (!user) {
-    return res.status(401).send("The username or password don't match");
+    return res.status(401).send({message:"The username or password don't match", user: user});
   }
 
   if (user.password !== req.body.password) {

--- a/user-routes.js
+++ b/user-routes.js
@@ -20,32 +20,37 @@ function getUserScheme(req) {
   
   var username;
   var type;
+  var userSearch = {};
 
   // The POST contains a username and not an email
   if(req.body.username) {
     username = req.body.username;
     type = 'username';
+    userSearch = { username: username };
   }
   // The POST contains an email and not an username
   else if(req.body.email) {
     username = req.body.email;
     type = 'email';
+    userSearch = { email: username };
   }
 
   return {
     username: username,
-    type: type
+    type: type,
+    userSearch: userSearch
   }
 }
 
 app.post('/users', function(req, res) {
   
-  userScheme = getUserScheme(req);  
+  var userScheme = getUserScheme(req);  
 
-  if (!req.body.username && !req.body.email || !req.body.password) {
+  if (!userScheme.username || !req.body.password) {
     return res.status(400).send("You must send the username and the password");
   }
-  if (_.find(users, {username: userScheme.username}) || _.find(users, {email: userScheme.username})) {
+
+  if (_.find(users, userScheme.userSearch)) {
    return res.status(400).send("A user with that username already exists");
   }
 
@@ -61,13 +66,14 @@ app.post('/users', function(req, res) {
 
 app.post('/sessions/create', function(req, res) {
 
-  userScheme = getUserScheme(req);
+  var userScheme = getUserScheme(req);
 
-  if (!req.body.username && !req.body.email || !req.body.password) {
+  if (!userScheme.username || !req.body.password) {
     return res.status(400).send("You must send the username and the password");
   }
 
-  var user = _.find(users, {username: userScheme.username}) || _.find(users, {email: userScheme.username});
+  var user = _.find(users, userScheme.userSearch);
+  
   if (!user) {
     return res.status(401).send({message:"The username or password don't match", user: user});
   }

--- a/user-routes.js
+++ b/user-routes.js
@@ -16,29 +16,40 @@ function createToken(user) {
   return jwt.sign(_.omit(user, 'password'), config.secret, { expiresInMinutes: 60*5 });
 }
 
-app.post('/users', function(req, res) {
-  var username;
-  var userScheme;
+function getUserScheme(req) {
   
+  var username;
+  var type;
+
   // The POST contains a username and not an email
   if(req.body.username) {
     username = req.body.username;
-    userScheme = 'username';
+    type = 'username';
   }
   // The POST contains an email and not an username
   else if(req.body.email) {
     username = req.body.email;
-    userScheme = 'email';
+    type = 'email';
   }
+
+  return {
+    username: username,
+    type: type
+  }
+}
+
+app.post('/users', function(req, res) {
+  
+  userScheme = getUserScheme(req);  
 
   if (!req.body.username && !req.body.email || !req.body.password) {
     return res.status(400).send("You must send the username and the password");
   }
-  if (_.find(users, {username: username}) || _.find(users, {email: username})) {
+  if (_.find(users, {username: userScheme.username}) || _.find(users, {email: userScheme.username})) {
    return res.status(400).send("A user with that username already exists");
   }
 
-  var profile = _.pick(req.body, userScheme, 'password', 'extra');
+  var profile = _.pick(req.body, userScheme.type, 'password', 'extra');
   profile.id = _.max(users, 'id').id + 1;
 
   users.push(profile);
@@ -50,25 +61,13 @@ app.post('/users', function(req, res) {
 
 app.post('/sessions/create', function(req, res) {
 
-  var username;
-  var userScheme;
-  
-  // The POST contains a username and not an email
-  if(req.body.username) {
-    username = req.body.username;
-    userScheme = 'username';
-  }
-  // The POST contains an email and not an username
-  else if(req.body.email) {
-    username = req.body.email;
-    userScheme = 'email';
-  }
+  userScheme = getUserScheme(req);
 
   if (!req.body.username && !req.body.email || !req.body.password) {
     return res.status(400).send("You must send the username and the password");
   }
 
-  var user = _.find(users, {username: username}) || _.find(users, {email: username});
+  var user = _.find(users, {username: userScheme.username}) || _.find(users, {email: userScheme.username});
   if (!user) {
     return res.status(401).send({message:"The username or password don't match", user: user});
   }


### PR DESCRIPTION
The aureliauth package assumes an email address is used for logging in. This addition gives people a choice of using a username or email as the user scheme for registration and login. 
