### PR TITLE
Replace deprecated `expiresInMinutes` with `expiresIn`

### DIFF
--- a/user-routes.js
+++ b/user-routes.js
@@ -13,7 +13,7 @@ var users = [{
 }];
 
 function createToken(user) {
-  return jwt.sign(_.omit(user, 'password'), config.secret, { expiresInMinutes: 60*5 });
+  return jwt.sign(_.omit(user, 'password'), config.secret, { expiresIn: 60*60*5 });
 }
 
 function getUserScheme(req) {


### PR DESCRIPTION
```
jsonwebtoken: expiresInMinutes and expiresInSeconds is deprecated. (user-routes.js:16:14)
Use "expiresIn" expressed in seconds.
```
