### PR TITLE
Fix deprecated expiresInMinutes

### DIFF
--- a/user-routes.js
+++ b/user-routes.js
@@ -13,7 +13,7 @@ var users = [{
 }];
 
 function createToken(user) {
-  return jwt.sign(_.omit(user, 'password'), config.secret, { expiresInMinutes: 60*5 });
+  return jwt.sign(_.omit(user, 'password'), config.secret, { expiresIn: '5m' });
 }
 
 function getUserScheme(req) {


### PR DESCRIPTION
`expiresInMinutes` en `expiresInSeconds` have been deprecated in favor of `expiresIn`.
`expiresIn: expressed in seconds or an string describing a time span rauchg/ms. Eg: 60, "2 days", "10h", "7d"`
