### PR TITLE
Fix relative path to absolute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If you have found a bug or if you have a feature request, please report them at 
 
 ## Author
 
-[Auth0](auth0.com)
+[Auth0](https://auth0.com)
 
 ## License
 


### PR DESCRIPTION
Typo: the path to auth0.com was relative instead of absolute in the docs.
