### PR TITLE
FIX #22 - now always return a quote

### DIFF
--- a/quoter.js
+++ b/quoter.js
@@ -2,6 +2,6 @@ var quotes = require('./quotes.json');
 
 exports.getRandomOne = function() {
   var totalAmount = quotes.length;
-  var rand = Math.ceil(Math.random() * totalAmount);
+  var rand = Math.ceil(Math.random() * (totalAmount - 1));
   return quotes[rand];
 }


### PR DESCRIPTION
The quoter.js can no longer attempt to return `undefined` at `quoteArr[arrayLength]` position. (0-based index vs 1-based index issue)
