### PR TITLE
Update quoter.js to ensure 0 index can be returned

### DIFF
--- a/quoter.js
+++ b/quoter.js
@@ -2,6 +2,6 @@ var quotes = require('./quotes.json');
 
 exports.getRandomOne = function() {
   var totalAmount = quotes.length;
-  var rand = Math.ceil(Math.random() * (totalAmount - 1));
+  var rand = Math.floor(Math.random() * totalAmount);
   return quotes[rand];
 }


### PR DESCRIPTION
The first (0 index in array) quote would never be returned. Using Math.floor corrects this.
