### PR TITLE
Updated Express error handling

### DIFF
--- a/server.js
+++ b/server.js
@@ -20,7 +20,7 @@ app.use(cors());
 
 app.use(function(err, req, res, next) {
   if (err.name === 'StatusError') {
-    res.send(err.status, err.message);
+    res.status(err.status).send(err.message);
   } else {
     next(err);
   }


### PR DESCRIPTION
`res.send(err.status, err.message);` has been depreciated in the current version of Express. `res.status(err.status).send(err.message);` is the updated way to handle custom status on a response. 

This commit fixes this bug.
